### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -42,4 +42,4 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: mvn clean deploy -P release -DskipTests --batch-modeSetting Up Github Secrets
+        run: mvn clean deploy -P release -DskipTests --batch-mode


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/maven-publish.yml` file. The change corrects a typo in the Maven deploy command.

* [`.github/workflows/maven-publish.yml`](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL45-R45): Fixed a typo by adding a missing space in the Maven deploy command.