### PR TITLE
Function Call Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # LLMTools
 Changelog
-| Version | Changes |
-|---------|---------|
-| 0.0.1 | Java Ollama Client for interacting with Ollama API|
+| Version | Changes | Bugs | Fixes |
+|---------|---------|------|-------|
+| 0.0.1 | Java Ollama Client for interacting with Ollama API|Stream endpoint||
+| 0.0.2 | Function Calling Support| |Stream endpoint|
 
 ## Ollama Client and Controller
 Java client for interacting with Ollama API.

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Similarities:
 The memory for the `/ollama/chat` endpoint is managed and allocated within the GPU and system memory, as indicated by various references to memory management in the repository. Specific handling of memory for devices is detailed in files like `ggml-cuda.cu` and other GU-related files.
 In a distributed system, if the memory used for maintaining chat context isn't persisted or shared across nodes, it can indeed be lost if the system state isn't properly synchronized or save.
 
-#### Function Calleing with `/ollama/chat` and `/ollama/generate`
+#### Function Calling with `/ollama/chat` and `/ollama/generate`
 `/ollama/chat`:
 - Supports function calling using the `tools` parameter.
 - The `tools` parameter allows specifying tools for the model to use if supported. This requires `stream` to be set to `false`.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>io.github.innobridge</groupId>
 	<artifactId>llmtools</artifactId>
-	<version>0.0.1</version>
+	<version>0.0.2-SNAPSHOT-1</version>
     <name>${project.groupId}:${project.artifactId}</name>
 	<description>Tools for interacting with LLMs</description>
     <url>https://github.com/innoBridge/LLMTools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>io.github.innobridge</groupId>
 	<artifactId>llmtools</artifactId>
-	<version>0.0.2-SNAPSHOT-1</version>
+	<version>0.0.2</version>
     <name>${project.groupId}:${project.artifactId}</name>
 	<description>Tools for interacting with LLMs</description>
     <url>https://github.com/innoBridge/LLMTools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>io.github.innobridge</groupId>
 	<artifactId>llmtools</artifactId>
-	<version>0.0.2</version>
+	<version>0.0.3-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
 	<description>Tools for interacting with LLMs</description>
     <url>https://github.com/innoBridge/LLMTools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>io.github.innobridge</groupId>
 	<artifactId>llmtools</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
+	<version>0.0.3</version>
     <name>${project.groupId}:${project.artifactId}</name>
 	<description>Tools for interacting with LLMs</description>
     <url>https://github.com/innoBridge/LLMTools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>io.github.innobridge</groupId>
 	<artifactId>llmtools</artifactId>
-	<version>0.0.3</version>
+	<version>0.0.4</version>
     <name>${project.groupId}:${project.artifactId}</name>
 	<description>Tools for interacting with LLMs</description>
     <url>https://github.com/innoBridge/LLMTools</url>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
                         </executions>
                         <configuration>
                             <doclint>none</doclint>
+                            <failOnError>false</failOnError> 
                         </configuration>
                     </plugin>
                     <plugin>

--- a/src/main/java/io/github/innobridge/llmtools/client/OllamaClient.java
+++ b/src/main/java/io/github/innobridge/llmtools/client/OllamaClient.java
@@ -3,12 +3,6 @@ package io.github.innobridge.llmtools.client;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Flux;
 
-import java.io.IOException;
-
-import org.springframework.web.multipart.MultipartFile;
-
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.github.innobridge.llmtools.models.request.EmbedRequest;
 import io.github.innobridge.llmtools.models.request.GenerateRequest;
 import io.github.innobridge.llmtools.models.request.PullRequest;

--- a/src/main/java/io/github/innobridge/llmtools/client/OllamaClientImpl.java
+++ b/src/main/java/io/github/innobridge/llmtools/client/OllamaClientImpl.java
@@ -39,11 +39,9 @@ import static io.github.innobridge.llmtools.constants.OllamaConstants.API_SHOW_R
 import static io.github.innobridge.llmtools.constants.OllamaConstants.API_BLOBS_ROUTE;
 import static io.github.innobridge.llmtools.constants.OllamaConstants.API_PS_ROUTE;
 import static io.github.innobridge.llmtools.constants.OllamaConstants.API_PULL_ROUTE;
-import static io.github.innobridge.llmtools.constants.OllamaConstants.V1_COMPLETIONS_ROUTE;
 import static io.github.innobridge.llmtools.constants.OllamaConstants.API_CHAT_ROUTE;
 import static io.github.innobridge.llmtools.constants.OllamaConstants.API_EMBED_ROUTE;
 import static io.github.innobridge.llmtools.constants.OllamaConstants.API_TAGS_ROUTE;
-import static io.github.innobridge.llmtools.constants.OllamaConstants.API_VERSION_ROUTE;
 
 /**
  * Implementation of the OllamaClient interface using WebClient.

--- a/src/main/java/io/github/innobridge/llmtools/constants/Models.java
+++ b/src/main/java/io/github/innobridge/llmtools/constants/Models.java
@@ -1,0 +1,21 @@
+package io.github.innobridge.llmtools.constants;
+
+public class Models {
+
+    // Llama 3.1 models
+    public static final String LLAMA_3_1 = "llama3.1:latest";
+    public static final String LLAMA_3_1_8B_INSTRUCT = "llama3.1:8b-instruct-q4_0";
+
+    // Llama 3.2 models
+    public static final String LLAMA_3_2 = "llama3.2:latest";
+    public static final String LLAMA_3_2_1B = "llama3.2:1b";
+    public static final String LLAMA_3_2_1B_INSTRUCT = "llama3.2:1b-instruct-q2_K";
+    public static final String LLAMA_3_2_3B_INSTRUCT = "llama3.2:3b-instruct-q4_0";
+
+    // Llava models
+    public static final String LLAVA = "llava:latest";
+
+    // Qwen models
+    public static final String QWEN_7B = "qwen:7b";
+    public static final String QWEN_32B = "qwen:32b";
+}

--- a/src/main/java/io/github/innobridge/llmtools/constants/OllamaConstants.java
+++ b/src/main/java/io/github/innobridge/llmtools/constants/OllamaConstants.java
@@ -128,5 +128,4 @@ public class OllamaConstants {
     public static final String EXPIRES_AT = "expires_at";
     public static final String SIZE_VRAM = "size_vram";
     public static final String MESSAGE = "message";
-
 }

--- a/src/main/java/io/github/innobridge/llmtools/constants/OllamaConstants.java
+++ b/src/main/java/io/github/innobridge/llmtools/constants/OllamaConstants.java
@@ -128,4 +128,27 @@ public class OllamaConstants {
     public static final String EXPIRES_AT = "expires_at";
     public static final String SIZE_VRAM = "size_vram";
     public static final String MESSAGE = "message";
+
+    // Functions
+    public static final String TOOLS_INDICATOR = ".Tools";
+
+    public static final String APPLY = "apply";
+    public static final String TO_STRING = "toString";
+    public static final String HASH_CODE = "hashCode";
+    public static final String EQUALS = "equals";
+    public static final String GET_CLASS = "getClass";
+    public static final String LAMBDA = "lambda$";
+    public static final String OBJECT = "Object";
+    public static final String GET = "get";
+    public static final String IS = "is";
+    public static final String STRING = "string";
+    public static final String INTEGER = "integer";
+    public static final String BOOLEAN = "boolean";
+    public static final String NUMBER = "number";
+
+    public static final String BYTE_SHORTHAND = "B";
+    public static final String KILO_BYTE_SHORTHAND = "KB";
+    public static final String MEGA_BYTE_SHORTHAND = "MB";
+    public static final String GIGA_BYTE_SHORTHAND = "GB";
+    public static final String TERA_BYTE_SHORTHAND = "TB";
 }

--- a/src/main/java/io/github/innobridge/llmtools/controller/FunctionController.java
+++ b/src/main/java/io/github/innobridge/llmtools/controller/FunctionController.java
@@ -2,11 +2,11 @@ package io.github.innobridge.llmtools.controller;
 
 import static io.github.innobridge.llmtools.constants.OllamaConstants.FUNCTION;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.github.innobridge.llmtools.client.OllamaClient;
 import io.github.innobridge.llmtools.function.BraveSearchService;
+import io.github.innobridge.llmtools.function.LLMFunction;
 import io.github.innobridge.llmtools.function.WeatherService;
 import io.github.innobridge.llmtools.models.Message;
 import io.github.innobridge.llmtools.models.request.ChatRequest;
@@ -92,9 +93,20 @@ public class FunctionController {
         return ollamaTools.getToolSupportingModelResponses(sortOrder);
     }
 
+    enum FunctionClass {
+        WEATHER_SERVICE,
+        BRAVE_SEARCH
+    }
+
+    private HashMap<FunctionClass, Class<? extends LLMFunction>> functionMap = new HashMap<>();
+    {
+        functionMap.put(FunctionClass.WEATHER_SERVICE, WeatherService.class);
+        functionMap.put(FunctionClass.BRAVE_SEARCH, BraveSearchService.class);
+    }
+
     @GetMapping("/convertToToolFunction")
-    public ToolFunction convertToToolFunction() {
-        return FunctionConverter.convertToToolFunction(WeatherService.class);
+    public ToolFunction convertToToolFunction(@RequestParam FunctionClass functionClass) {
+        return FunctionConverter.convertToToolFunction(functionMap.get(functionClass));
     }
 
     @GetMapping("/execute/weatherservice/first")

--- a/src/main/java/io/github/innobridge/llmtools/controller/FunctionController.java
+++ b/src/main/java/io/github/innobridge/llmtools/controller/FunctionController.java
@@ -1,0 +1,266 @@
+package io.github.innobridge.llmtools.controller;
+
+import static io.github.innobridge.llmtools.constants.OllamaConstants.FUNCTION;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.innobridge.llmtools.client.OllamaClient;
+import io.github.innobridge.llmtools.function.BraveSearchService;
+import io.github.innobridge.llmtools.function.WeatherService;
+import io.github.innobridge.llmtools.models.Message;
+import io.github.innobridge.llmtools.models.request.ChatRequest;
+import io.github.innobridge.llmtools.models.request.Tool;
+import io.github.innobridge.llmtools.models.request.ToolFunction;
+import io.github.innobridge.llmtools.models.response.ModelAndSize;
+import io.github.innobridge.llmtools.models.response.SortOrder;
+import io.github.innobridge.llmtools.models.response.ToolCallFunction;
+import io.github.innobridge.llmtools.tools.FunctionConverter;
+import io.github.innobridge.llmtools.tools.Tools;
+
+@RestController
+@RequestMapping("/function")
+public class FunctionController {
+
+    private OllamaClient ollamaClient;
+
+    private Tools ollamaTools;
+
+    public FunctionController(OllamaClient ollamaClient, Tools ollamaTools) {
+        this.ollamaClient = ollamaClient;
+        this.ollamaTools = ollamaTools;
+    }
+
+    @GetMapping("/hello")
+    public String hello() {
+        var builder = ChatRequest.builder();
+        builder.model("llama3.2");
+        builder.messages(
+            List.of(
+                Message.builder()
+                    .role("user")
+                    .content("What is the weather today in Paris? and in New York?")
+                    .build()
+            )
+        );
+        builder.tools(
+            List.of(
+                new Tool(
+                    FUNCTION,
+                    new ToolFunction(
+                        "getCurrentWeather",
+                        "Get the current weather for a location",
+                        ToolFunction.Parameters.builder("object")
+                            .required(List.of("location", "format"))
+                            .properties(
+                                Map.of(
+                                    "location", ToolFunction.Property.builder("string").description("The location to get the weather for, e.g. San Francisco, CA").build(),
+                                    "format", ToolFunction.Property.builder("string").description("The format of the response, e.g. celsius or fahrenheit")
+                                    .enumValues(List.of("celsius", "fahrenheit")).build()
+                                )
+                            ).build()
+                        )
+                    )
+                )
+        );
+        builder.stream(false);
+
+        return ollamaClient.chat(builder.build()).block().getMessage().getToolCalls().stream()
+            .map(toolCall -> toolCall.getFunction().getName() + " : " + toolCall.getFunction().getArguments().toString() + "\n")
+            .reduce("", String::concat);
+    }
+
+    @GetMapping("/hastool/{modelname}")
+    public String hasTool(@PathVariable String modelname) {
+        boolean hasTools = ollamaTools.isToolsSupported(modelname);
+        
+        
+        return "Model: " + modelname + "\n" +
+               "Has Tool Support: " + hasTools + "\n\n";    
+    }
+
+    @GetMapping("/toolmodels")
+    public List<ModelAndSize> getToolModels(@RequestParam(required = false) SortOrder sortOrder) {
+        return ollamaTools.getToolSupportingModelResponses(sortOrder);
+    }
+
+    @GetMapping("/convertToToolFunction")
+    public ToolFunction convertToToolFunction() {
+        return FunctionConverter.convertToToolFunction(WeatherService.class);
+    }
+
+    @GetMapping("/execute/weatherservice/first")
+    public Optional<?> executeWeatherServiceFirst(@RequestParam String model, @RequestParam String prompt) {
+
+        var builder = ChatRequest.builder();
+        builder.model(model);
+        builder.messages(
+            List.of(
+                Message.builder()
+                    .role("user")
+                    .content(prompt) 
+                    .build()
+            )
+        );
+        builder.stream(false);
+
+        ToolFunction toolFunction = FunctionConverter.convertToToolFunction(WeatherService.class);
+
+        Tool tool = new Tool(
+            FUNCTION,
+            toolFunction
+        );
+        builder.tools(List.of(tool));
+        var result = ollamaTools.functionCall(builder.build(), List.of(tool));        
+        return result.executeFirst(WeatherService.class);
+    }
+
+    @GetMapping("/execute/weatherservice/last")
+    public Optional<?> executeWeatherServiceLast(@RequestParam String model, @RequestParam String prompt) {
+
+        var builder = ChatRequest.builder();
+        builder.model(model);
+        builder.messages(
+            List.of(
+                Message.builder()
+                    .role("user")
+                    .content(prompt) 
+                    .build()
+            )
+        );
+        builder.stream(false);
+
+        ToolFunction toolFunction = FunctionConverter.convertToToolFunction(WeatherService.class);
+
+        Tool tool = new Tool(
+            FUNCTION,
+            toolFunction
+        );
+        builder.tools(List.of(tool));
+        var result = ollamaTools.functionCall(builder.build(), List.of(tool));        
+        return result.executeLast(WeatherService.class);
+    }
+
+    @GetMapping("/execute/weatherservice/all")
+    public List<Optional<?>> executeWeatherServiceAll(@RequestParam String model, @RequestParam String prompt) {
+
+        var builder = ChatRequest.builder();
+        builder.model(model);
+        builder.messages(
+            List.of(
+                Message.builder()
+                    .role("user")
+                    .content(prompt) 
+                    .build()
+            )
+        );
+        builder.stream(false);
+
+        ToolFunction toolFunction = FunctionConverter.convertToToolFunction(WeatherService.class);
+
+        Tool tool = new Tool(
+            FUNCTION,
+            toolFunction
+        );
+        builder.tools(List.of(tool));
+        var result = ollamaTools.functionCall(builder.build(), List.of(tool));        
+        return result.executeAll(WeatherService.class);
+    }
+
+    @GetMapping("/execute/bravesearch/all")
+    public List<Optional<?>> executeBraveSearch(@RequestParam String model, @RequestParam String prompt) {
+        var builder = ChatRequest.builder();
+        builder.model(model);
+        builder.messages(
+            List.of(
+                Message.builder()
+                    .role("user")
+                    .content(prompt) 
+                    .build()
+            )
+        );
+        builder.stream(false);
+
+        ToolFunction toolFunction = FunctionConverter.convertToToolFunction(BraveSearchService.class);
+        Tool tool = new Tool(FUNCTION, toolFunction);
+        builder.tools(List.of(tool));
+        
+        var result = ollamaTools.functionCall(builder.build(), List.of(tool));        
+        return result.executeAll(BraveSearchService.class);
+    }
+
+    @GetMapping("/execute/all")
+    public List<Optional<?>> executeAll(@RequestParam String model, @RequestParam String prompt) {
+        var builder = ChatRequest.builder();
+        builder.model(model);
+        builder.messages(
+            List.of(
+                Message.builder()
+                    .role("user")
+                    .content(prompt) 
+                    .build()
+            )
+        );
+        builder.stream(false);
+        
+        var result = ollamaTools.functionCall(builder.build(), List.of(
+            new Tool(FUNCTION, FunctionConverter.convertToToolFunction(WeatherService.class)),
+            new Tool(FUNCTION, FunctionConverter.convertToToolFunction(BraveSearchService.class))
+        ));
+        return result.executeAll();
+    }
+
+    @GetMapping("/invokes/weatherservice")
+    public Boolean invokesWeatherService(@RequestParam String model, @RequestParam String prompt) {
+        var builder = ChatRequest.builder();
+        builder.model(model);
+        builder.messages(
+            List.of(
+                Message.builder()
+                    .role("user")
+                    .content(prompt) 
+                    .build()
+            )
+        );
+        builder.stream(false);
+
+        ToolFunction toolFunction = FunctionConverter.convertToToolFunction(WeatherService.class);
+
+        Tool tool = new Tool(
+            FUNCTION,
+            toolFunction
+        );
+        builder.tools(List.of(tool));
+        var result = ollamaTools.functionCall(builder.build(), List.of(tool));     
+        return result.invokesFunction(WeatherService.class);
+    }
+
+    @GetMapping("/functioncall")
+    public List<ToolCallFunction> getFunctionCalls(@RequestParam String model, @RequestParam String prompt) {
+        var builder = ChatRequest.builder();
+        builder.model(model);
+        builder.messages(
+            List.of(
+                Message.builder()
+                    .role("user")
+                    .content(prompt) 
+                    .build()
+            )
+        );
+        builder.stream(false);
+
+        var result = ollamaTools.functionCall(builder.build(), List.of(
+            new Tool(FUNCTION, FunctionConverter.convertToToolFunction(WeatherService.class)),
+            new Tool(FUNCTION, FunctionConverter.convertToToolFunction(BraveSearchService.class))
+        ));        
+        return result.getFunctionCalls();
+    }
+}

--- a/src/main/java/io/github/innobridge/llmtools/exceptions/LLMFunctionException.java
+++ b/src/main/java/io/github/innobridge/llmtools/exceptions/LLMFunctionException.java
@@ -1,0 +1,11 @@
+package io.github.innobridge.llmtools.exceptions;
+
+public class LLMFunctionException extends RuntimeException {
+    public LLMFunctionException(String message) {
+        super(message);
+    }
+
+    public LLMFunctionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/innobridge/llmtools/function/BraveSearchService.java
+++ b/src/main/java/io/github/innobridge/llmtools/function/BraveSearchService.java
@@ -43,11 +43,6 @@ public class BraveSearchService implements LLMFunction<BraveSearchService.Reques
     }
 
     @Override
-    public Response apply(Map<String, Object> arguments) {
-        return apply(fromArguments(arguments));    
-    }
-
-    @Override
     public Response apply(Request request) {
         if (request.query() == null || request.query().trim().isEmpty()) {
             throw new LLMFunctionException("Query is required");

--- a/src/main/java/io/github/innobridge/llmtools/function/BraveSearchService.java
+++ b/src/main/java/io/github/innobridge/llmtools/function/BraveSearchService.java
@@ -1,0 +1,99 @@
+package io.github.innobridge.llmtools.function;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.github.innobridge.llmtools.exceptions.LLMFunctionException;
+import io.github.innobridge.llmtools.tools.FunctionDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@FunctionDefinition(
+    name = "brave_search",
+    description = "Search the web when data is not in training data"
+)
+public class BraveSearchService implements LLMFunction<BraveSearchService.Request, BraveSearchService.Response> {
+
+    private final WebClient braveSearchClient;
+    private final String apiKey;
+
+    public BraveSearchService(String apiKey, WebClient braveSearchClient) {
+        this.apiKey = apiKey;
+        this.braveSearchClient = braveSearchClient;
+    }
+
+    @Override
+    public Request fromArguments(Map<String, Object> arguments) {
+        try {
+            String query = (String) arguments.get("query");
+            if (query == null || query.trim().isEmpty()) {
+                throw new LLMFunctionException("Query is required");
+            }
+            return new Request(query);
+        } catch (ClassCastException e) {
+            throw new LLMFunctionException("Invalid argument type", e);
+        }
+    }
+
+    @Override
+    public Response apply(Map<String, Object> arguments) {
+        return apply(fromArguments(arguments));    
+    }
+
+    @Override
+    public Response apply(Request request) {
+        if (request.query() == null || request.query().trim().isEmpty()) {
+            throw new LLMFunctionException("Query is required");
+        }
+
+        try {
+            return braveSearchClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/res/v1/web/search")
+                    .queryParam("q", request.query())
+                    .queryParam("count", "3")
+                    .build())
+                .header("Accept", "application/json")
+                .header("Accept-Encoding", "gzip")
+                .header("X-Subscription-Token", apiKey)
+                .retrieve()
+                .bodyToMono(Response.class)
+                .block();
+        } catch (Exception e) {
+            throw new LLMFunctionException("Failed to perform Brave search", e);
+        }
+    }
+
+    @JsonInclude(Include.NON_NULL)
+    record Request(
+        @JsonProperty(required = true)
+        @JsonPropertyDescription("The query to search for")
+        String query
+    ) {}
+
+    record Response(
+        @JsonProperty("web")
+        WebResults web
+    ) {
+        record WebResults(
+            @JsonProperty("results")
+            List<WebResult> results
+        ) {
+            record WebResult(
+                @JsonProperty("title")
+                String title,
+                @JsonProperty("url")
+                String url,
+                @JsonProperty("description")
+                String description
+            ) {}
+        }
+    }
+}

--- a/src/main/java/io/github/innobridge/llmtools/function/LLMFunction.java
+++ b/src/main/java/io/github/innobridge/llmtools/function/LLMFunction.java
@@ -1,0 +1,10 @@
+package io.github.innobridge.llmtools.function;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public interface LLMFunction<T, R> extends Function<T, R> {
+    T fromArguments(Map<String, Object> arguments);
+
+    R apply(Map<String, Object> arguments);
+}

--- a/src/main/java/io/github/innobridge/llmtools/function/LLMFunction.java
+++ b/src/main/java/io/github/innobridge/llmtools/function/LLMFunction.java
@@ -6,5 +6,7 @@ import java.util.function.Function;
 public interface LLMFunction<T, R> extends Function<T, R> {
     T fromArguments(Map<String, Object> arguments);
 
-    R apply(Map<String, Object> arguments);
+    default R apply(Map<String, Object> arguments) {
+        return apply(fromArguments(arguments));
+    }
 }

--- a/src/main/java/io/github/innobridge/llmtools/function/WeatherService.java
+++ b/src/main/java/io/github/innobridge/llmtools/function/WeatherService.java
@@ -1,0 +1,149 @@
+package io.github.innobridge.llmtools.function;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.github.innobridge.llmtools.exceptions.LLMFunctionException;
+import io.github.innobridge.llmtools.tools.FunctionDefinition;
+
+@Service
+@FunctionDefinition(
+    name = "get_current_weather",
+    description = "Get the current weather in a given location"
+)
+public class WeatherService implements LLMFunction<WeatherService.Request, WeatherService.Response> {
+    
+    private final WebClient weatherClient;
+    private final String apiKey;
+    
+    public WeatherService(WebClient weatherClient, String apiKey) {
+        this.weatherClient = weatherClient;
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public Request fromArguments(Map<String, Object> arguments) {
+        try {
+            String location = (String) arguments.get("location");
+            if (location == null || location.trim().isEmpty()) {
+                throw new LLMFunctionException("Location is required");
+            }
+            Format format = Format.CELSIUS;  // Default format
+            String formatStr = (String) arguments.get("format");
+            if (formatStr != null && !formatStr.trim().isEmpty() && 
+                formatStr.toLowerCase().equals("fahrenheit")) {
+                format = Format.FAHRENHEIT;
+            }
+    
+            return new Request(location, format);
+        } catch (ClassCastException e) {
+            throw new LLMFunctionException("Invalid argument type", e);
+        }
+    }
+
+    @Override
+    public Response apply(Map<String, Object> arguments) {
+        return apply(fromArguments(arguments));
+    }
+
+    @Override
+    public Response apply(Request request) {
+        if (request.location() == null || request.location().trim().isEmpty()) {
+            throw new LLMFunctionException("Location is required");
+        }
+
+        try {
+            String uri = UriComponentsBuilder.fromPath("/current.json")
+                    .queryParam("key", apiKey)
+                    .queryParam("q", request.location())
+                    .queryParam("aqi", "no")
+                    .build()
+                    .toUriString();
+
+            Response response = weatherClient.post()
+                    .uri(uri)
+                    .header("Content-Type", "application/json")
+                    .bodyValue("")  // Empty body for POST request
+                    .retrieve()
+                    .bodyToMono(Response.class)
+                    .block();
+
+            return response;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new LLMFunctionException("Failed to get weather", e);
+        }
+    }
+
+    enum Format {
+        CELSIUS("celsius"), 
+        FAHRENHEIT("fahrenheit");
+
+        public final String formatName;
+
+        Format(String formatName) {
+            this.formatName = formatName;
+        }
+
+        @Override
+        public String toString() {
+            return formatName;
+        }
+    }
+
+    @JsonInclude(Include.NON_NULL)
+    record Request(
+        @JsonProperty(required = true) 
+        @JsonPropertyDescription("The city and state e.g. San Francisco, CA") 
+        String location,
+        @JsonProperty(required = true) 
+        @JsonPropertyDescription("The format to return the weather in, e.g. 'celsius' or 'fahrenheit'") 
+        Format format) {
+    }
+    
+    record Response(
+        Location location,
+        Current current
+    ) {
+        record Current(
+            double temp_c,
+            // double temp_f,
+            // @JsonProperty("wind_mph")
+            // double windMph,
+            // @JsonProperty("wind_kph")
+            // double windKph,
+            // @JsonProperty("precip_mm")
+            // double precipMm,
+            @JsonProperty("precip_in")
+            double precipIn,
+            // int humidity,
+            // int cloud,
+            // double uv,
+            Condition condition
+        ) {}
+    
+        record Condition(
+            String text
+        ) {}
+
+        record Location(
+            String name,
+            // String region,
+            String country
+            // double lat,
+            // double lon,
+            // @JsonProperty("tz_id")
+            // String tzId,
+            // String localtime
+        ) {}
+    }
+    
+}

--- a/src/main/java/io/github/innobridge/llmtools/function/WeatherService.java
+++ b/src/main/java/io/github/innobridge/llmtools/function/WeatherService.java
@@ -97,7 +97,7 @@ public class WeatherService implements LLMFunction<WeatherService.Request, Weath
     @JsonInclude(Include.NON_NULL)
     record Request(
         @JsonProperty(required = true) 
-        @JsonPropertyDescription("The city and state e.g. San Francisco, CA") 
+        @JsonPropertyDescription("The name of the city e.g. San Francisco, CA") 
         String location,
         @JsonProperty(required = true) 
         @JsonPropertyDescription("The format to return the weather in, e.g. 'celsius' or 'fahrenheit'") 

--- a/src/main/java/io/github/innobridge/llmtools/function/WeatherService.java
+++ b/src/main/java/io/github/innobridge/llmtools/function/WeatherService.java
@@ -50,11 +50,6 @@ public class WeatherService implements LLMFunction<WeatherService.Request, Weath
     }
 
     @Override
-    public Response apply(Map<String, Object> arguments) {
-        return apply(fromArguments(arguments));
-    }
-
-    @Override
     public Response apply(Request request) {
         if (request.location() == null || request.location().trim().isEmpty()) {
             throw new LLMFunctionException("Location is required");

--- a/src/main/java/io/github/innobridge/llmtools/models/Message.java
+++ b/src/main/java/io/github/innobridge/llmtools/models/Message.java
@@ -7,11 +7,15 @@ import static io.github.innobridge.llmtools.constants.OllamaConstants.TOOL_CALLS
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
 
 import io.github.innobridge.llmtools.models.response.ToolCall;
 
 import java.util.List;
 
+@Data
+@Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Message {
     @JsonProperty(ROLE)
@@ -22,14 +26,4 @@ public class Message {
     private List<byte[]> images;
     @JsonProperty(TOOL_CALLS)
     private List<ToolCall> toolCalls;
-
-    // Getters and Setters
-    public String getRole() { return role; }
-    public void setRole(String role) { this.role = role; }
-    public String getContent() { return content; }
-    public void setContent(String content) { this.content = content; }
-    public List<byte[]> getImages() { return images; }
-    public void setImages(List<byte[]> images) { this.images = images; }
-    public List<ToolCall> getToolCalls() { return toolCalls; }
-    public void setToolCalls(List<ToolCall> toolCalls) { this.toolCalls = toolCalls; }
 }

--- a/src/main/java/io/github/innobridge/llmtools/models/request/ToolFunction.java
+++ b/src/main/java/io/github/innobridge/llmtools/models/request/ToolFunction.java
@@ -33,6 +33,36 @@ public class ToolFunction {
         @JsonProperty(PROPERTIES)
         private Map<String, Property> properties;
 
+        @lombok.Generated
+        public static class ParametersBuilder {
+            private String type;
+            private List<String> required;
+            private Map<String, Property> properties;
+
+            ParametersBuilder() {
+            }
+
+            public ParametersBuilder type(String type) {
+                this.type = type;
+                return this;
+            }
+
+            public ParametersBuilder required(List<String> required) {
+                this.required = required;
+                return this;
+            }
+
+            public ParametersBuilder properties(Map<String, Property> properties) {
+                this.properties = properties;
+                return this;
+            }
+
+            public Parameters build() {
+                return new Parameters(type, required, properties);
+            }
+        }
+
+        @lombok.Generated
         public static ParametersBuilder builder(String type) {
             return hiddenBuilder().type(type);
         }
@@ -51,6 +81,36 @@ public class ToolFunction {
         @JsonProperty(ENUM)
         private List<String> enumValues;
 
+        @lombok.Generated
+        public static class PropertyBuilder {
+            private String type;
+            private String description;
+            private List<String> enumValues;
+
+            PropertyBuilder() {
+            }
+
+            public PropertyBuilder type(String type) {
+                this.type = type;
+                return this;
+            }
+
+            public PropertyBuilder description(String description) {
+                this.description = description;
+                return this;
+            }
+
+            public PropertyBuilder enumValues(List<String> enumValues) {
+                this.enumValues = enumValues;
+                return this;
+            }
+
+            public Property build() {
+                return new Property(type, description, enumValues);
+            }
+        }
+
+        @lombok.Generated
         public static PropertyBuilder builder(String type) {
             return hiddenBuilder().type(type);
         }

--- a/src/main/java/io/github/innobridge/llmtools/models/request/ToolFunction.java
+++ b/src/main/java/io/github/innobridge/llmtools/models/request/ToolFunction.java
@@ -4,7 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import static io.github.innobridge.llmtools.constants.OllamaConstants.*;
 import java.util.List;
 import java.util.Map;
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 
+@Data
+@AllArgsConstructor
 public class ToolFunction {
     @JsonProperty(NAME)
     private String name;
@@ -15,6 +20,9 @@ public class ToolFunction {
     @JsonProperty(PARAMETERS)
     private Parameters parameters;
 
+    @Data
+    @Builder(builderMethodName = "hiddenBuilder")
+    @AllArgsConstructor
     public static class Parameters {
         @JsonProperty(TYPE)
         private String type;
@@ -24,8 +32,15 @@ public class ToolFunction {
 
         @JsonProperty(PROPERTIES)
         private Map<String, Property> properties;
+
+        public static ParametersBuilder builder(String type) {
+            return hiddenBuilder().type(type);
+        }
     }
 
+    @Data
+    @Builder(builderMethodName = "hiddenBuilder")
+    @AllArgsConstructor
     public static class Property {
         @JsonProperty(TYPE)
         private String type;
@@ -35,7 +50,9 @@ public class ToolFunction {
 
         @JsonProperty(ENUM)
         private List<String> enumValues;
-    }
 
-    // Add getters and setters
+        public static PropertyBuilder builder(String type) {
+            return hiddenBuilder().type(type);
+        }
+    }
 }

--- a/src/main/java/io/github/innobridge/llmtools/models/response/ModelAndSize.java
+++ b/src/main/java/io/github/innobridge/llmtools/models/response/ModelAndSize.java
@@ -1,0 +1,11 @@
+package io.github.innobridge.llmtools.models.response;
+
+import static io.github.innobridge.llmtools.constants.OllamaConstants.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ModelAndSize(
+    @JsonProperty(MODEL) String model,
+    @JsonProperty(SIZE) String size) { }

--- a/src/main/java/io/github/innobridge/llmtools/models/response/SortOrder.java
+++ b/src/main/java/io/github/innobridge/llmtools/models/response/SortOrder.java
@@ -1,0 +1,7 @@
+package io.github.innobridge.llmtools.models.response;
+
+public enum SortOrder {
+    NONE,
+    ASC,
+    DESC
+}

--- a/src/main/java/io/github/innobridge/llmtools/models/response/ToolCall.java
+++ b/src/main/java/io/github/innobridge/llmtools/models/response/ToolCall.java
@@ -4,8 +4,10 @@ import static io.github.innobridge.llmtools.constants.OllamaConstants.FUNCTION;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder
 public class ToolCall {
     @JsonProperty(FUNCTION)
     private ToolCallFunction function;

--- a/src/main/java/io/github/innobridge/llmtools/tools/FunctionConverter.java
+++ b/src/main/java/io/github/innobridge/llmtools/tools/FunctionConverter.java
@@ -1,0 +1,133 @@
+package io.github.innobridge.llmtools.tools;
+
+import io.github.innobridge.llmtools.models.request.ToolFunction;
+
+import static io.github.innobridge.llmtools.constants.OllamaConstants.APPLY;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.BOOLEAN;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.EQUALS;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.GET;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.GET_CLASS;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.HASH_CODE;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.INTEGER;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.IS;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.LAMBDA;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.NUMBER;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.OBJECT;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.STRING;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.TO_STRING;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+/**
+ * Utility class to convert annotated functions to ToolFunction format
+ */
+public class FunctionConverter {
+    
+    /**
+     * Converts a class annotated with @FunctionDefinition to a ToolFunction
+     * @param clazz The class to convert
+     * @return ToolFunction representation of the annotated class
+     */
+    public static ToolFunction convertToToolFunction(Class<?> clazz) {
+        // Get the parameters from the apply method if it's a Function interface
+        Method applyMethod = Arrays.stream(clazz.getMethods())
+            .filter(method -> method.getName().equals(APPLY))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Class must implement Function interface"));
+        
+
+        Class<?> parameterType = applyMethod.getParameterTypes()[0];
+
+        // Build the ToolFunction
+        return new ToolFunction(
+            getAnnotatedName(clazz),
+            getAnnotatedDescription(clazz),
+            buildParameters(parameterType)
+        );
+    }
+
+    private static ToolFunction.Parameters buildParameters(Class<?> parameterType) {
+        // For this example, we'll assume the parameter type is a record with getters
+        // You can expand this to handle more complex parameter types
+        Method[] methods = parameterType.getDeclaredMethods();
+        
+        Map<String, ToolFunction.Property> properties = Arrays.stream(methods)
+            .filter(method -> method.getParameterCount() == 0) // Only get methods with no parameters
+            .filter(method -> !method.getName().equals(TO_STRING))
+            .filter(method -> !method.getName().equals(HASH_CODE))
+            .filter(method -> !method.getName().equals(EQUALS))
+            .filter(method -> !method.getName().equals(GET_CLASS))
+            .filter(method -> !method.getName().startsWith(LAMBDA))
+            .collect(Collectors.<Method, String, ToolFunction.Property>toMap(
+                FunctionConverter::getPropertyName,
+                method -> {
+                    ToolFunction.Property.PropertyBuilder builder = ToolFunction.Property.builder(getPropertyType(method.getReturnType()));
+                    
+                    // Set description from annotation if present
+                    JsonPropertyDescription desc = method.getAnnotation(JsonPropertyDescription.class);
+                    if (desc != null) {
+                        builder.description(desc.value());
+                    }                    
+
+                    // Set enum values if it's an enum type
+                    if (method.getReturnType().isEnum()) {
+                        builder.enumValues(Arrays.stream(method.getReturnType().getEnumConstants())
+                            .map(Object::toString)
+                            .toList());
+                    }                    
+
+                    return builder.build();
+                },
+                (existing, replacement) -> existing // Keep the first occurrence in case of duplicates
+            ));
+
+
+        return ToolFunction.Parameters.builder(OBJECT)
+            .properties(properties)
+            .required(properties.keySet().stream().toList())
+            .build();
+    }
+
+    private static String getPropertyName(Method method) {
+        String name = method.getName();
+        if (name.startsWith(GET)) {
+            name = name.substring(3);
+        } else if (name.startsWith(IS)) {
+            name = name.substring(2);
+        }
+        // Convert first character to lowercase
+        if (name.length() > 0) {
+            name = Character.toLowerCase(name.charAt(0)) + (name.length() > 1 ? name.substring(1) : "");
+        }
+        return name;
+    }
+
+    private static String getPropertyType(Class<?> type) {
+        if (type == String.class) return STRING;
+        if (type == Integer.class || type == int.class) return INTEGER;
+        if (type == Boolean.class || type == boolean.class) return BOOLEAN;
+        if (type == Double.class || type == double.class) return NUMBER;
+        return STRING; // default to string for unknown types
+    }
+
+    public static String getAnnotatedName(Class<?> clazz) {
+        FunctionDefinition annotation = clazz.getAnnotation(FunctionDefinition.class);
+        if (annotation == null) {
+            throw new IllegalArgumentException("Class " + clazz.getName() + " must be annotated with @FunctionDefinition");
+        }
+        return annotation.name();
+    }
+
+    public static String getAnnotatedDescription(Class<?> clazz) {
+        FunctionDefinition annotation = clazz.getAnnotation(FunctionDefinition.class);
+        if (annotation == null) {
+            throw new IllegalArgumentException("Class " + clazz.getName() + " must be annotated with @FunctionDefinition");
+        }
+        return annotation.description();
+    }
+}

--- a/src/main/java/io/github/innobridge/llmtools/tools/FunctionDefinition.java
+++ b/src/main/java/io/github/innobridge/llmtools/tools/FunctionDefinition.java
@@ -1,0 +1,23 @@
+package io.github.innobridge.llmtools.tools;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to define function metadata for LLM tools.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface FunctionDefinition {
+    /**
+     * The name of the function
+     */
+    String name();
+
+    /**
+     * The description of what the function does
+     */
+    String description();
+}

--- a/src/main/java/io/github/innobridge/llmtools/tools/FunctionsExecutor.java
+++ b/src/main/java/io/github/innobridge/llmtools/tools/FunctionsExecutor.java
@@ -1,0 +1,169 @@
+package io.github.innobridge.llmtools.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.github.innobridge.llmtools.exceptions.LLMFunctionException;
+import io.github.innobridge.llmtools.function.LLMFunction;
+import io.github.innobridge.llmtools.models.response.ToolCallFunction;
+
+// @Slf4j
+@SuppressWarnings("rawtypes")
+public class FunctionsExecutor {
+    private List<ToolCallFunction> functionCalls;
+    private final Map<String, LLMFunction> functionRepository;
+
+    public FunctionsExecutor(List<ToolCallFunction> functionCalls, Map<String, LLMFunction> functionRepository) {
+        this.functionCalls = functionCalls;
+        this.functionRepository = functionRepository;
+    }
+
+    public Optional<?> executeFirst(Class clazz) {
+        Optional<List<ToolCallFunction>> toolCallFunctions = getToolCallFunctions(clazz);
+        List<ToolCallFunction> filteredCalls = toolCallFunctions.get();
+        if (filteredCalls.isEmpty() || toolCallFunctions.isEmpty()) {
+            return Optional.empty();
+        } 
+
+        ToolCallFunction firstCall = filteredCalls.getFirst();
+
+        LLMFunction<?, ?> function = functionRepository.get(FunctionConverter.getAnnotatedName(clazz));
+
+        try {
+            return Optional.of(function.apply(firstCall.getArguments()));
+        } catch (LLMFunctionException e) {
+            // Log the specific error if needed
+            return Optional.empty();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    public Optional<?> executeLast(Class clazz) {
+        Optional<List<ToolCallFunction>> toolCallFunctions = getToolCallFunctions(clazz);
+        List<ToolCallFunction> filteredCalls = toolCallFunctions.get();
+        if (filteredCalls.isEmpty() || toolCallFunctions.isEmpty()) {
+            return Optional.empty();
+        } 
+        
+        ToolCallFunction firstCall = filteredCalls.getLast();
+
+        LLMFunction<?, ?> function = functionRepository.get(FunctionConverter.getAnnotatedName(clazz));
+
+        try {
+            return Optional.of(function.apply(firstCall.getArguments()));
+        } catch (LLMFunctionException e) {
+            // Log the specific error if needed
+            return Optional.empty();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    public List<Optional<?>> executeAll(Class clazz) {
+        Optional<List<ToolCallFunction>> toolCallFunctions = getToolCallFunctions(clazz);
+        List<ToolCallFunction> filteredCalls = toolCallFunctions.get();
+        if (filteredCalls.isEmpty() || toolCallFunctions.isEmpty()) {
+            return new ArrayList<>();
+        } 
+        
+        LLMFunction<?, ?> function = functionRepository.get(FunctionConverter.getAnnotatedName(clazz));
+
+        return filteredCalls.stream()
+            .map(call -> {
+                try {
+                    return Optional.of(function.apply(call.getArguments()));
+                } catch (LLMFunctionException e) {
+                    return Optional.empty();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return Optional.empty();
+                }
+            })
+            .collect(Collectors.toList());
+    }
+
+    public List<Optional<?>> executeAll() {
+        return functionCalls.stream()
+            .filter(call -> functionRepository.containsKey(call.getName()))
+            .map(call -> {
+                try {
+                    return Optional.of(functionRepository.get(call.getName()).apply(call.getArguments()));
+                } catch (LLMFunctionException e) {
+                    return Optional.empty();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return Optional.empty();
+                }
+            })
+            .collect(Collectors.toList());
+    }
+
+    public Boolean invokesFunction(Class clazz) {
+        return functionCalls.stream()
+            .filter(call -> call.getName().equals(FunctionConverter.getAnnotatedName(clazz)))
+            .findFirst()
+            .isPresent();
+    }
+
+    public List<ToolCallFunction> getFunctionCalls() {
+        return functionCalls;
+    }
+
+    private Optional<List<ToolCallFunction>> getToolCallFunctions(Class clazz) {
+        String name = FunctionConverter.getAnnotatedName(clazz);
+        if (functionCalls == null 
+            || functionCalls.isEmpty() 
+            || !functionRepository.containsKey(name)) {
+            return Optional.empty();
+        }
+        
+        List<ToolCallFunction> filteredCalls = functionCalls.stream()
+            .filter(call -> call.getName().equals(name))
+            .collect(Collectors.toList());
+        if (filteredCalls.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(filteredCalls);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("FunctionsExecutor[\n");
+        
+        // Format function calls
+        sb.append("  Function Calls:\n");
+        if (functionCalls != null && !functionCalls.isEmpty()) {
+            for (ToolCallFunction call : functionCalls) {
+                sb.append("    - Name: ").append(call.getName())
+                  .append(", Index: ").append(call.getIndex())
+                  .append(", Arguments: ").append(call.getArguments())
+                  .append("\n");
+            }
+        } else {
+            sb.append("    (none)\n");
+        }
+        
+        // Format function repository
+        sb.append("  Function Repository:\n");
+        if (functionRepository != null && !functionRepository.isEmpty()) {
+            functionRepository.forEach((name, func) -> {
+                sb.append("    - ").append(name)
+                  .append(": ").append(func.getClass().getSimpleName())
+                  .append("\n");
+            });
+        } else {
+            sb.append("    (empty)\n");
+        }
+        
+        sb.append("]");
+        return sb.toString();
+    }
+    
+}

--- a/src/main/java/io/github/innobridge/llmtools/tools/OllamaTools.java
+++ b/src/main/java/io/github/innobridge/llmtools/tools/OllamaTools.java
@@ -1,0 +1,131 @@
+package io.github.innobridge.llmtools.tools;
+
+import org.springframework.stereotype.Component;
+import io.github.innobridge.llmtools.client.OllamaClient;
+import io.github.innobridge.llmtools.function.LLMFunction;
+import io.github.innobridge.llmtools.models.request.ShowRequest;
+import io.github.innobridge.llmtools.models.request.Tool;
+import io.github.innobridge.llmtools.models.request.ChatRequest;
+import io.github.innobridge.llmtools.models.response.ListModelResponse;
+import io.github.innobridge.llmtools.models.response.ListResponse;
+import io.github.innobridge.llmtools.models.response.ModelAndSize;
+import io.github.innobridge.llmtools.models.response.ModelResponse;
+import io.github.innobridge.llmtools.models.response.SortOrder;
+import io.github.innobridge.llmtools.models.response.ToolCall;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Comparator;
+import java.util.HashMap;
+
+import static io.github.innobridge.llmtools.constants.OllamaConstants.BYTE_SHORTHAND;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.GIGA_BYTE_SHORTHAND;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.KILO_BYTE_SHORTHAND;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.MEGA_BYTE_SHORTHAND;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.TERA_BYTE_SHORTHAND;
+import static io.github.innobridge.llmtools.constants.OllamaConstants.TOOLS_INDICATOR;
+import static io.github.innobridge.llmtools.tools.FunctionConverter.getAnnotatedName;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+@SuppressWarnings("rawtypes")
+public class OllamaTools implements Tools {
+        
+        private final OllamaClient ollamaClient;
+        private final Map<String, LLMFunction> functionRepository = new HashMap<>();
+
+        public OllamaTools(OllamaClient ollamaClient, List<LLMFunction> functions) {
+            this.ollamaClient = ollamaClient;
+            functions.forEach(function -> functionRepository.put(getAnnotatedName(function.getClass()), function));
+        }
+
+        @Override
+        public boolean isToolsSupported(String modelName) {
+            var builder = ShowRequest.builder().model(modelName);
+            var showResponse = ollamaClient.show(builder.build());
+            var response = showResponse.block();
+            String template = response.getTemplate();
+            
+            return template != null && template.contains(TOOLS_INDICATOR);
+        }
+
+        @Override
+        public List<String> getToolSupportingModels() {
+            var listResponse = ollamaClient.listModels().block();
+            if (listResponse == null || listResponse.getModels() == null) {
+                return new ArrayList<>();
+            }
+
+            return listResponse.getModels().stream()
+                .map(model -> model.getName())
+                .filter(this::isToolsSupported)
+                .collect(Collectors.toList());
+        }
+
+        @Override
+        public List<ModelAndSize> getToolSupportingModelResponses(SortOrder sortOrder) {
+            ListResponse listResponse = ollamaClient.listModels().block();
+            if (listResponse == null || listResponse.getModels() == null) {
+                return new ArrayList<>();
+            }
+
+            return sortModelsBySize(listResponse, sortOrder);
+        }
+
+        @Override
+        public FunctionsExecutor functionCall(ChatRequest chatRequest, List<Tool> tools) {
+            if (!isToolsSupported(chatRequest.getModel())) {
+                throw new IllegalArgumentException("Model " + chatRequest.getModel() + " does not support function calls");
+            }
+            chatRequest.setTools(tools);
+            List<ToolCall> toolCalls = ollamaClient.chat(chatRequest).block().getMessage().getToolCalls();
+            
+            return new FunctionsExecutor(
+                toolCalls == null ? new ArrayList<>() : toolCalls.stream()
+                    .map(toolCall -> toolCall.getFunction())
+                    .collect(Collectors.toList())    
+            , this.functionRepository);
+        }
+
+        private String formatSize(long bytes) {
+            if (bytes < 1024) {
+                return bytes + " " + BYTE_SHORTHAND;
+            }
+            
+            final String[] units = new String[] { 
+                KILO_BYTE_SHORTHAND, 
+                MEGA_BYTE_SHORTHAND, 
+                GIGA_BYTE_SHORTHAND, 
+                TERA_BYTE_SHORTHAND };
+
+            int unitIndex = -1;
+            double size = bytes;
+        
+            while (size >= 1024 && unitIndex < units.length - 1) {
+                size /= 1024;
+                unitIndex++;
+            }
+        
+            return String.format("%.1f", size).replaceAll("\\.?0*$", "") + " " + units[unitIndex];
+        }
+
+        private List<ModelAndSize> sortModelsBySize(ListResponse listResponse, SortOrder sortOrder) {
+            Stream<ListModelResponse> supportedModels = listResponse.getModels().stream()
+            .filter(model -> isToolsSupported(model.getName())); 
+            
+            if (sortOrder != null && sortOrder != SortOrder.NONE) {
+                if (sortOrder == SortOrder.ASC) {
+                    supportedModels = supportedModels.sorted(Comparator.comparing(ModelResponse::getSize));
+                } else {
+                    supportedModels = supportedModels.sorted(Comparator.comparing(ModelResponse::getSize).reversed());
+                }
+            };
+
+            return supportedModels.map(model -> new ModelAndSize(model.getName(), formatSize(model.getSize())))
+                .collect(Collectors.toList());
+        }
+        
+}

--- a/src/main/java/io/github/innobridge/llmtools/tools/Tools.java
+++ b/src/main/java/io/github/innobridge/llmtools/tools/Tools.java
@@ -1,0 +1,18 @@
+package io.github.innobridge.llmtools.tools;
+
+import java.util.List;
+
+import io.github.innobridge.llmtools.models.request.ChatRequest;
+import io.github.innobridge.llmtools.models.request.Tool;
+import io.github.innobridge.llmtools.models.response.ModelAndSize;
+import io.github.innobridge.llmtools.models.response.SortOrder;
+
+public interface Tools {
+    boolean isToolsSupported(String modelName);
+
+    List<String> getToolSupportingModels();
+
+    List<ModelAndSize> getToolSupportingModelResponses(SortOrder sortOrder);
+
+    FunctionsExecutor functionCall(ChatRequest chatRequest, List<Tool> tools);
+}


### PR DESCRIPTION
This change introduce the `Tools` utility for function calling.

We do this by calling Ollama's API with our function definition and getting a list of function calls.

The functions that you will be using for function calling will be a Java class implements the `LLMFunctions` interface and is annotated with function definition so that our `FunctionConverter` class can convert the Java class into a payload that  satisfy Ollama's function calling specification.

`Tools.functionCall` returns Ollama's API and returns an `FunctionsExecutor` object.

`FunctionsExecutor` contains a lists of function calls with the following methods:
- `executeFirst(Class clazz)`: Which execute the first occurrence of a function in the lists of function.
- `executeLast(Class clazz)`: Which execute the last occurrence of a function in the lists of function.
- `executeAll(Class clazz)`: Which execute all the occurrences of a function in the lists of function.
- `executeAll()`: Which execute the all functions in the lists of functions that is registered in OllamaTools function repository.


